### PR TITLE
debugger: fix package config parsing

### DIFF
--- a/debugger/src/main.rs
+++ b/debugger/src/main.rs
@@ -89,7 +89,7 @@ struct PackageCfg {
 }
 
 fn parse_package_cfg(src: &str) -> Result<PackageCfg> {
-    let (package, trace) = src.split_once('/').expect("delimiter");
+    let (package, trace) = src.rsplit_once('/').expect("delimiter");
     Ok(PackageCfg {
         package: package.into(),
         trace: trace.into(),


### PR DESCRIPTION
## PR Info

- Context: https://discord.com/channels/273534239310479360/1183801680307949651/1183814427154333827

## Bug Fixes

- [x] debugger: split the last `/` from `--package challenges/day11/full`, package path being `challenges/day11` and trace level set to `full`

<img width="1904" alt="image" src="https://github.com/SeaQL/FireDBG.for.Rust/assets/30400950/9608455a-2e1c-4032-a619-3f2aadf386f3">
