### PR TITLE
feat: Add Ubuntu 24.04 support

### DIFF
--- a/build/Dockerfile.ubuntu24.04
+++ b/build/Dockerfile.ubuntu24.04
@@ -1,0 +1,39 @@
+# 1. Build the Docker image
+#    ```
+#    docker build --no-cache -t firedbg-ubuntu24.04 -f build/Dockerfile.ubuntu24.04 .
+#    # Or, keeping the full build log
+#    docker build --no-cache --progress plain -t firedbg-ubuntu24.04 -f build/Dockerfile.ubuntu24.04 .
+#    ```
+# 2. Start a Docker container and mount the directories to the container
+#    ```
+#    docker run --name firedbg-ubuntu24.04 --rm -it -v $(pwd):/FireDBG.for.Rust firedbg-ubuntu24.04
+#    ```
+# 3. Build release
+#    ```
+#    cd /FireDBG.for.Rust && sh build-tools/release-x86_64-ubuntu.sh
+#    ```
+
+FROM ubuntu:24.04
+
+# apt install without interactive dialogue
+ARG DEBIAN_FRONTEND=noninteractive
+
+# The following dependencies are required
+RUN apt update
+# Needed in `release.sh`
+RUN apt install curl unzip -y
+# Needed to build FireDBG executables and run self tests
+RUN apt install clang build-essential pkg-config libssl-dev -y
+RUN apt install liblldb-18 python3-lldb-18 libc++-dev libc++abi1-18 -y
+# Link c++ to `clang` instead of g++
+RUN update-alternatives --set c++ /usr/bin/clang++
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal -y
+ENV PATH "/root/.cargo/bin:$PATH"
+
+# Create symbolic links such that `cargo` and `lldb` can locate them
+RUN ln -s /usr/lib/x86_64-linux-gnu/liblldb-18.so.1 /usr/lib/x86_64-linux-gnu/liblldb.so
+
+# For unknown reason, if LLDB cannot locate `lldb-server`
+RUN export LLDB_DEBUGSERVER_PATH=/usr/lib/llvm-18/bin/lldb-server-18.0.0

--- a/install.sh
+++ b/install.sh
@@ -151,6 +151,9 @@ get_architecture() {
                     case "$_os_id_like" in
                         ubuntu*)
                             case "$_os_version_id" in
+                                24*) # Ubuntu Noble
+                                    local _ostype="ubuntu24.04"
+                                    ;;
                                 21*) # Ubuntu Jammy
                                     local _ostype="ubuntu22.04"
                                     ;;
@@ -165,6 +168,9 @@ get_architecture() {
                     esac
             esac
             case "$_ostype" in
+                ubuntu24*)
+                    check_apt_install libc++abi1-18
+                    ;;
                 ubuntu22*)
                     check_apt_install libc++abi1-15
                     ;;


### PR DESCRIPTION
## PR Info

- Discussion : https://github.com/SeaQL/FireDBG.for.Rust/discussions/47

## New Features

- [ ] Add Ubuntu 24.04 : add the dockerfile in build directory. I copy/paste the one for Ubuntu 22.04 and did some adjustments  so that it build :
  * liblldb-18 python3-lldb-18 libc++-dev libc++abi1-18
  * remove libc++abi.so symlink as it already exists and point to `/usr/lib/llvm-18/lib/libc++abi.so.1.0`
  * I tested running a `cargo check` as I don't have the build-tools folder


## Changes

- [ ] Update the `install.sh` script
