### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -52,8 +52,8 @@ main() {
     local _arch="$RETVAL"
     assert_nz "$_arch" "arch"
 
-    which rustup > /dev/null 2>&1
-    need_ok "failed to find Rust installation, is rustup installed?"
+    which rustc > /dev/null 2>&1
+    need_ok "failed to find Rust installation, is rust installed?"
 
     get_firedbg_version || return 1
     local _firedbg_version="$RETVAL"


### PR DESCRIPTION
## PR Info

## Bug Fixes

I have rust installed via system package and no rustup. Seems like this check does more harm than good... unless this tool requires multiple rust toolchains for some reason